### PR TITLE
Update regression.py

### DIFF
--- a/regression.py
+++ b/regression.py
@@ -29,7 +29,7 @@ loss = tf.reduce_mean(tf.square(y - y_data))
 optimizer = tf.train.GradientDescentOptimizer(0.5)
 train = optimizer.minimize(loss)
 
-init = tf.initialize_all_variables()
+init = tf.global_variables_initializer()
 
 sess = tf.Session()
 sess.run(init)


### PR DESCRIPTION
remove the warning
WARNING:tensorflow:From regression.py:32: initialize_all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.
Instructions for updating:
Use `tf.global_variables_initializer` instead.